### PR TITLE
release: align package metadata with 0.5.0

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -12,7 +12,7 @@ body:
     id: version
     attributes:
       label: Praxist version or commit
-      placeholder: "praxist 0.3.0 or commit SHA"
+      placeholder: "praxist 0.5.0 or commit SHA"
     validations:
       required: true
   - type: input

--- a/praxist/plugins/workflow_stages/research_loop/startup.py
+++ b/praxist/plugins/workflow_stages/research_loop/startup.py
@@ -14,6 +14,7 @@ from typing import Any
 
 import yaml
 
+from praxist import __version__
 from praxist.core.budget import policy_for_ref
 from praxist.core.cache import build_cache_policy
 from praxist.core.credentials import (
@@ -717,7 +718,7 @@ def prepare_research_loop_plugin_run(
         "created_at": previous_run_metadata.get("created_at") or startup_time,
         "started_at": startup_time,
         "finalized_at": None,
-        "praxist_version": "0.3.0",
+        "praxist_version": __version__,
         "git_commit": source_snapshot["git_commit"],
         "workspace_hash": source_snapshot["workspace_hash"],
         "source_hash_algorithm": source_snapshot["source_hash_algorithm"],

--- a/praxist/testing/fake_workflow_fixture.py
+++ b/praxist/testing/fake_workflow_fixture.py
@@ -8,6 +8,7 @@ from typing import Any
 
 import yaml
 
+from praxist import __version__
 from praxist.core.budget import policy_for_ref
 from praxist.core.cache import build_cache_policy
 from praxist.core.credentials import (
@@ -118,7 +119,7 @@ def run_fake_workflow_fixture(
         "created_at": utc_now(),
         "started_at": utc_now(),
         "finalized_at": None,
-        "praxist_version": "0.3.0",
+        "praxist_version": __version__,
         "git_commit": source_snapshot["git_commit"],
         "workspace_hash": source_snapshot["workspace_hash"],
         "source_hash_algorithm": source_snapshot["source_hash_algorithm"],

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "praxist"
-version = "0.3.0"
+version = "0.5.0"
 description = "Praxist — multi-agent, multi-generation autonomous ML research system"
 readme = "README.md"
 license = { file = "LICENSE.md" }


### PR DESCRIPTION
## Summary

- set the authoritative Python distribution version to `0.5.0`
- derive real and conformance-run metadata from `praxist.__version__` instead of a stale literal
- update the bug-report version example

This leaves example compatibility floors, Rust harness versions, measured baselines, and test fixture versions unchanged because they are not Praxist release metadata.

## Validation

- `ruff check praxist/ tests/`
- `ruff format --check praxist/ tests/`
- `pyrefly check`
- `pytest tests/unit --tb=short -q`: 2,893 passed, 268 subtests passed
- built `praxist-0.5.0-py3-none-any.whl` and `praxist-0.5.0.tar.gz`
- `twine check --strict`: both distributions passed
- wheel contents include both Python and Rust rocket examples
- isolated wheel install reports `praxist 0.5.0` and lists both examples

## Release Follow-up

The existing annotated `0.5.0` tag points to the pre-fix `main` commit. After this PR is merged and before any production PyPI upload, recreate that tag at the merged `main` commit and re-run the release preflight.
