### PR TITLE
fix: preserve Codex Desktop originator metadata

### DIFF
--- a/praxist/plugins/agent_runtimes/codex_sdk/adapter.py
+++ b/praxist/plugins/agent_runtimes/codex_sdk/adapter.py
@@ -81,6 +81,8 @@ _SUBSCRIPTION_RUNTIME_OVERRIDES = (
 _SAFE_PROCESS_ENV_KEYS = frozenset(
     {
         "ALL_PROXY",
+        # Codex treats an empty override as an explicit blank runtime name.
+        "CODEX_INTERNAL_ORIGINATOR_OVERRIDE",
         "CURL_CA_BUNDLE",
         "HOME",
         "HTTPS_PROXY",

--- a/tests/unit/test_codex_sdk_auth.py
+++ b/tests/unit/test_codex_sdk_auth.py
@@ -427,6 +427,34 @@ class CodexSdkRuntimeCredentialHookTest(unittest.TestCase):
         discover.assert_called_once_with("model_provider:openai_compatible")
 
 
+class CodexSdkProcessEnvironmentTest(unittest.TestCase):
+    def test_codex_originator_is_preserved_without_forwarding_credentials(self) -> None:
+        from praxist.plugins.agent_runtimes.codex_sdk.adapter import _client_process_env
+
+        source = {
+            "CODEX_INTERNAL_ORIGINATOR_OVERRIDE": "Codex Desktop",
+            "OPENAI_API_KEY": "openai-secret",
+            "PATH": "/test/bin",
+            "UNRELATED_SECRET": "other-secret",
+        }
+        with patch.dict(os.environ, source, clear=True):
+            process_env = _client_process_env(
+                "openai",
+                source,
+                Path("/private/codex"),
+                subscription=True,
+            )
+
+        self.assertEqual(
+            process_env["CODEX_INTERNAL_ORIGINATOR_OVERRIDE"],
+            "Codex Desktop",
+        )
+        self.assertEqual(process_env["PATH"], "/test/bin")
+        self.assertEqual(process_env["CODEX_HOME"], "/private/codex")
+        self.assertEqual(process_env["OPENAI_API_KEY"], "")
+        self.assertEqual(process_env["UNRELATED_SECRET"], "")
+
+
 class ChatGptModelCatalogTest(unittest.TestCase):
     def test_catalog_uses_private_staged_auth_and_closes_resources(self) -> None:
         from praxist.plugins.agent_runtimes.codex_sdk import adapter


### PR DESCRIPTION
## Summary

Codex Desktop exports `CODEX_INTERNAL_ORIGINATOR_OVERRIDE`. The Codex SDK process environment currently blanks every inherited variable outside its allowlist, so that override becomes an explicit empty string. Codex then reports a user agent beginning with `/0.147.0`, and `openai-codex` rejects the initialize response because the runtime name is empty. In practice, `praxist doctor --codex-native` reports that it cannot read the ChatGPT Codex model catalog.

Preserve this non-secret origin label in the scoped SDK process environment. Add an offline regression test that verifies the label survives while the OpenAI key and an unrelated secret remain blanked.

## Scope

- Affected modules or public contracts: `agent_runtime:codex_sdk` process environment and its authentication tests.
- Compatibility considerations: behavior changes only when the host supplies `CODEX_INTERNAL_ORIGINATOR_OVERRIDE`; all credential isolation behavior remains intact.
- Task-agnostic rationale: Codex-native readiness and runtime initialization should work when Praxist is invoked from Codex Desktop.

## Verification

Passed locally:

- `uv run pytest tests/unit/test_codex_sdk_auth.py --tb=short -q` — 20 passed, 8 subtests passed.
- `uv run ruff check praxist/ tests/`.
- `uv run ruff format --check praxist/ tests/`.
- `uv run python scripts/run_test_coverage.py integration` — 13 tests, 6 skipped.
- `uv run python scripts/build_docs_site.py`.
- `git diff --check`.
- Live Codex-native reproduction: the model-catalog probe failed with the inherited originator blanked and passed for `gpt-5.6-luna` when the value was preserved.

Broader local checks were also attempted. On this macOS host, the full unit suite reached 2,860 passes, 1 skip, and 33 unrelated failures, primarily from `/var` versus `/private/var` path identity, Linux `/proc` assumptions, generated example cache detection, and local provider configuration. Pyrefly also reports three existing unbound-name errors in `experiment_process.py`. Python 3.11 `compileall` reaches a vendored Rust utility that uses Python 3.12 f-string syntax. The latest upstream `main` Linux CI run is green.

## Checklist

- [x] The change is focused and does not include unrelated generated files.
- [x] Tests cover the affected behavior.
- [x] Documentation, templates, examples, and skills were updated where needed.
- [x] No credentials, private task data, or research-run artifacts are included.
- [x] New dependencies and copied assets include their source and license terms.
- [x] I have read `.github/CONTRIBUTING.md` and the contribution terms in `LICENSE.md`.
