### PR TITLE
Fix grammar: incorrect article 'an' before consonant sound

### DIFF
--- a/skills/praxist-onboarding/SKILL.md
+++ b/skills/praxist-onboarding/SKILL.md
@@ -41,7 +41,7 @@ Check these surfaces:
 
 2. **Source checkouts near the current directory**
    - Inspect the current directory and one parent level for Praxist source trees.
-   - A source tree is likely present when `pyproject.toml` declares `name = "praxist"` and an `praxist/` package directory exists.
+   - A source tree is likely present when `pyproject.toml` declares `name = "praxist"` and a `praxist/` package directory exists.
    - If a source tree is git-managed, report branch and cleanliness with `git status --short --branch`.
 
 3. **Agent skill installation**


### PR DESCRIPTION
## Summary

This PR fixes a grammar issue in `skills/praxist-onboarding/SKILL.md` (line 44).

## Problem

Incorrect article 'an' used before 'praxist', which starts with a consonant sound. Should be 'a praxist/'.

The problematic text:

```markdown
an `praxist/` package directory exists
```

## Fix

Replaced with:

```markdown
a `praxist/` package directory exists
```

## Type of Change

- [x] Documentation fix (grammar, spelling, logical error)
- [ ] Code change
- [ ] Breaking change

## Checklist

- [x] Documentation files only
- [x] No code changes
- [x] Fix verified against original text