### PR TITLE
Fix grammar: missing article before 'consent prompt'

### DIFF
--- a/docs/legal/PRIVACY.md
+++ b/docs/legal/PRIVACY.md
@@ -25,7 +25,7 @@ Praxist collects product-usage data only when **all three** of the following con
 
 1. the installed build contains an approved collection transport;
 2. product-usage collection is enabled for that build; and
-3. you separately and explicitly select **"Share product usage"** after this Notice is made available for review, or reply `Yes` / `Agree` to consent prompt shown during installation.
+3. you separately and explicitly select **"Share product usage"** after this Notice is made available for review, or reply `Yes` / `Agree` to a consent prompt shown during installation.
 
 Please note:
 


### PR DESCRIPTION
## Summary

This PR fixes a grammar issue in `docs/legal/PRIVACY.md` (line 28).

## Problem

Missing article before 'consent prompt'. Should read 'to a consent prompt'.

The problematic text:

```markdown
reply `Yes` / `Agree` to consent prompt shown during installation
```

## Fix

Replaced with:

```markdown
reply `Yes` / `Agree` to a consent prompt shown during installation
```

## Type of Change

- [x] Documentation fix (grammar, spelling, logical error)
- [ ] Code change
- [ ] Breaking change

## Checklist

- [x] Documentation files only
- [x] No code changes
- [x] Fix verified against original text