### PR TITLE
Fix grammar: incorrect article 'a' before vowel sound

### DIFF
--- a/docs/operations/DOCUMENTATION.md
+++ b/docs/operations/DOCUMENTATION.md
@@ -26,7 +26,7 @@
 
 | File | Responsibility |
 | --- | --- |
-| `consent.py` | Consent-state storage: a `unset` / `granted` / `denied` state machine that fails closed; atomic writes (0600 permissions); consent records are bound to the Notice version — a version mismatch counts as no consent; Agent-assisted replies recognize only `Yes` / `Agree` / `No` / `Disagree` |
+| `consent.py` | Consent-state storage: an `unset` / `granted` / `denied` state machine that fails closed; atomic writes (0600 permissions); consent records are bound to the Notice version — a version mismatch counts as no consent; Agent-assisted replies recognize only `Yes` / `Agree` / `No` / `Disagree` |
 | `identity.py` | Environment identity: generated at random via UUIDv4 and persisted locally in `environment.json`; never derived from any personal, device, or task information |
 | `paths.py` | Fixed per-OS local file paths (Section 5); no environment-variable or project-level overrides |
 | `lifecycle.py` | Generation of run-level event IDs, telemetry run IDs, event sequence numbers, and the four lifecycle events |


### PR DESCRIPTION
## Summary

This PR fixes a grammar issue in `docs/operations/DOCUMENTATION.md` (line 29).

## Problem

Incorrect article 'a' used before 'unset', which starts with a vowel sound. Should be 'an `unset`'.

The problematic text:

```markdown
a `unset` / `granted` / `denied` state machine
```

## Fix

Replaced with:

```markdown
an `unset` / `granted` / `denied` state machine
```

## Type of Change

- [x] Documentation fix (grammar, spelling, logical error)
- [ ] Code change
- [ ] Breaking change

## Checklist

- [x] Documentation files only
- [x] No code changes
- [x] Fix verified against original text