### PR TITLE
fix: normalize stop signal paths for relative run dirs

### DIFF
--- a/praxist/plugins/workflow_stages/research_loop/backend/run_lifecycle.py
+++ b/praxist/plugins/workflow_stages/research_loop/backend/run_lifecycle.py
@@ -184,7 +184,7 @@ def _resolve_stop_signal_path(run_dir: Path, raw_path: str) -> Path | None:
         resolved_candidate.relative_to(resolved_run_root)
     except ValueError:
         return None
-    if _has_symlink_component(run_root, candidate):
+    if _has_symlink_component(resolved_run_root, resolved_candidate):
         return None
     return candidate
 

--- a/tests/unit/test_run_lifecycle_contracts.py
+++ b/tests/unit/test_run_lifecycle_contracts.py
@@ -212,6 +212,36 @@ class RunLifecycleGateContractsTest(unittest.TestCase):
                 "absolute_run_local",
             )
 
+    def test_relative_run_dir_accepts_an_absolute_run_local_stop_signal(self) -> None:
+        with tempfile.TemporaryDirectory(dir=Path.cwd()) as tmp:
+            root = Path(tmp).relative_to(Path.cwd())
+            run_dir = root / "run"
+            run_dir.mkdir()
+            signal = (run_dir / "run_control" / "stop.json").resolve()
+
+            write_external_stop_signal(
+                run_dir,
+                {"reason": "absolute_run_local"},
+                stop_signal_path=str(signal),
+            )
+
+            self.assertTrue(signal.is_file())
+            decision = evaluate_run_stop_gate(
+                task_spec=SimpleNamespace(
+                    run_lifecycle=SimpleNamespace(
+                        max_wall_clock_hours=None,
+                        stop_signal_path=str(signal),
+                    )
+                ),
+                run_dir=run_dir,
+                run_started_at_seconds=10.0,
+                now_seconds=20.0,
+                next_generation=1,
+                generations_completed=1,
+            )
+            self.assertTrue(decision.should_stop)
+            self.assertEqual(decision.signal_evidence["reason"], "absolute_run_local")
+
     def test_stop_signal_paths_must_be_run_local_plain_paths(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)


### PR DESCRIPTION
## Summary

Fixes #8.

Normalize the run root and candidate stop-signal path before the symlink
component walk. This allows a valid absolute `stop_signal_path` under a
relative `run_dir` while preserving containment and symlink rejection.

## Scope

- Affected modules or public contracts:
  - `run_lifecycle` stop-signal path validation.
  - Lifecycle unit contracts.
- Compatibility considerations:
  - Existing absolute and relative in-run paths remain supported.
  - Outside-root and symlinked paths remain rejected.
- Task-agnostic rationale:
  - Run lifecycle control paths must not depend on how the caller represents
    the same run directory.

## Verification

- `uv run pytest tests/unit/test_run_lifecycle_contracts.py --tb=short -q`
  — 9 passed.
- `uv run python -m unittest discover -s tests -q`
  — 3,080 passed, 6 skipped.
- `uv run ruff check ...`
- `uv run pyrefly check`
- `uv run python scripts/build_docs_site.py`
- `git diff --check`

## Checklist

- [x] The change is focused and does not include unrelated generated files.
- [x] Tests cover the affected behavior.
- [x] Documentation, templates, examples, and skills were updated where needed.
- [x] No credentials, private task data, or research-run artifacts are included.
- [x] New dependencies and copied assets include their source and license terms.
- [x] I have read `.github/CONTRIBUTING.md` and the contribution terms in `LICENSE.md`.
