### PR TITLE
Graduate redaction module from Pyrefly excludes

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -145,7 +145,6 @@ project-excludes = [
     "old",
     "templates",
     "praxist/core/modeling.py",
-    "praxist/core/redaction.py",
     "praxist/core/replay.py",
     "praxist/core/role_skills.py",
     "praxist/core/tool_servers.py",


### PR DESCRIPTION
## Summary

- Graduates `praxist/core/redaction.py` from the Pyrefly type-check exclusion list.
- Keeps the change scoped to the existing type backfill policy documented in `pyproject.toml`.

Closes #46.

## Verification

```bash
uv run pyrefly check
python -m unittest tests.core.test_foundation tests.unit.test_reviewer_stage -q
python -m compileall -q praxist/core/redaction.py
uv run ruff check praxist/core/redaction.py tests/core/test_foundation.py tests/unit/test_reviewer_stage.py
uv run ruff format --check praxist/core/redaction.py tests/core/test_foundation.py tests/unit/test_reviewer_stage.py
git diff --check
```

