### PR TITLE
feat(providers): Cloudflare Workers AI provider + the two runtime fixes it needs

### DIFF
--- a/docs/guides/agent-runtimes.md
+++ b/docs/guides/agent-runtimes.md
@@ -130,6 +130,7 @@ The Codex app-server consumes the Responses protocol. API provider routing is:
 | OpenAI / `model_provider:openai_compatible` | Direct SDK/app-server connection |
 | `model_provider:deepseek_alias` | Private run-scoped `codex-relay` to DeepSeek Chat Completions |
 | `model_provider:openrouter` | Private run-scoped `codex-relay` to OpenRouter Chat Completions |
+| `model_provider:cloudflare` | Private run-scoped `codex-relay` to Cloudflare Workers AI Chat Completions |
 
 Praxist starts and stops the relay; operators must not launch a relay per peer.
 The relay listens only on an ephemeral local port and receives only the selected

--- a/docs/guides/model-providers.md
+++ b/docs/guides/model-providers.md
@@ -10,6 +10,23 @@ Agent runtime plugins execute the agent loops.
 - `model_provider:openai_compatible` for OpenAI-compatible endpoints.
 - `model_provider:anthropic_messages` for native Anthropic Messages style.
 - `model_provider:deepseek_alias` for DeepSeek-compatible aliases.
+- `model_provider:cloudflare` for Cloudflare Workers AI.
+
+### Cloudflare Workers AI
+
+Workers AI is OpenAI-compatible only; it publishes no Anthropic Messages
+route, so it is compatible with `agent_runtime:codex_sdk` and not with
+`agent_runtime:claude_sdk`. Its endpoint base is account-scoped rather than
+fixed: `https://api.cloudflare.com/client/v4/accounts/{account_id}/ai/v1`,
+interpolated from `CLOUDFLARE_ACCOUNT_ID`. Set `CLOUDFLARE_BASE_URL` to
+override the whole base URL, and `CLOUDFLARE_API_KEY` for the bearer
+credential.
+
+The manifest declares the `cloudflare_workers_ai` API format rather than
+`openai_compatible` for one reason: Workers AI model ids are full
+`@cf/vendor/model` paths, and the generic OpenAI-compatible normalization
+strips everything before the first `/`. The wire protocol is otherwise
+plain OpenAI chat-completions.
 
 API provider names represent API format and routing. A task or operator may
 override the `ModelProfile` used by a stage.

--- a/docs/reference/plugins.md
+++ b/docs/reference/plugins.md
@@ -18,6 +18,8 @@ This page documents executable generic plugin boundaries.
 
 ::: praxist.plugins.model_providers.deepseek_alias.adapter
 
+::: praxist.plugins.model_providers.cloudflare.adapter
+
 ## Workflow Stage
 
 ::: praxist.plugins.workflow_stages.research_loop.startup

--- a/praxist/cli/_env.py
+++ b/praxist/cli/_env.py
@@ -9,6 +9,13 @@ from __future__ import annotations
 
 import os
 
+from praxist.core.cloudflare import (
+    CLOUDFLARE_KEY_VAR,
+    CLOUDFLARE_PROVIDER,
+    CLOUDFLARE_PROVIDER_REF,
+    workers_ai_base_url,
+)
+
 AGENT_SYSTEM_VALUES: tuple[str, ...] = (
     "claude_sdk",
     "codex_sdk",
@@ -37,6 +44,7 @@ PROVIDER_KEY_MAP: dict[str, str] = {
     "groq": "GROQ_API_KEY",
     "xai": "XAI_API_KEY",
     "openrouter": "OPENROUTER_API_KEY",
+    CLOUDFLARE_PROVIDER: CLOUDFLARE_KEY_VAR,
     "brave": "BRAVE_API_KEY",
 }
 """Known provider/tool credentials accepted by Praxist operator configuration."""
@@ -46,6 +54,7 @@ PROVIDER_REF_FOR_SHORT_NAME: dict[str, str] = {
     "openai": "model_provider:openai_compatible",
     "openrouter": "model_provider:openrouter",
     "deepseek": "model_provider:deepseek_alias",
+    CLOUDFLARE_PROVIDER: CLOUDFLARE_PROVIDER_REF,
 }
 """Canonical plugin ref for every built-in model provider."""
 
@@ -83,3 +92,15 @@ def agent_system_for_runtime_ref(runtime_ref: str) -> str | None:
         if normalized == candidate:
             return agent_system
     return None
+
+
+def provider_base_url(provider: str) -> str:
+    """Return the OpenAI-compatible base URL for a built-in provider.
+
+    Cloudflare Workers AI is account-scoped, so its URL is resolved at call
+    time from the environment instead of being a static table entry.
+    """
+    normalized = provider.strip().lower()
+    if normalized == CLOUDFLARE_PROVIDER:
+        return workers_ai_base_url()
+    return PROVIDER_BASE_URL.get(normalized, "")

--- a/praxist/cli/start.py
+++ b/praxist/cli/start.py
@@ -97,6 +97,8 @@ from praxist.cli.registry import (
     write_entry,
 )
 from praxist.cli.status import pid_is_alive, read_ps_table, registry_command_matches
+from praxist.core.cloudflare import CLOUDFLARE_DEFAULT_MODEL as CLOUDFLARE_MODEL
+from praxist.core.cloudflare import CLOUDFLARE_PROVIDER
 from praxist.task_spec import load_task_spec
 
 if TYPE_CHECKING:  # pragma: no cover - import only for static type checkers
@@ -129,10 +131,12 @@ OPENROUTER_PROVIDER_REF = PROVIDER_REF_FOR_SHORT_NAME["openrouter"]
 ANTHROPIC_PROVIDER_REF = PROVIDER_REF_FOR_SHORT_NAME["anthropic"]
 OPENAI_PROVIDER_REF = PROVIDER_REF_FOR_SHORT_NAME["openai"]
 DEEPSEEK_PROVIDER_REF = PROVIDER_REF_FOR_SHORT_NAME["deepseek"]
+CLOUDFLARE_PROVIDER_REF = PROVIDER_REF_FOR_SHORT_NAME[CLOUDFLARE_PROVIDER]
 
 OPENROUTER_DEFAULT_MODEL = "anthropic/claude-opus-4.7"
 ANTHROPIC_DEFAULT_MODEL = "claude-opus-4-7"
 DEEPSEEK_DEFAULT_MODEL = "deepseek-v4-pro[1m]"
+CLOUDFLARE_DEFAULT_MODEL = CLOUDFLARE_MODEL
 
 # Back-compat alias retained so callers that imported the old constant
 # from previous PRs keep working until they migrate to
@@ -842,6 +846,8 @@ def _resolve_model(raw: str | None, provider_ref: str, agent_system: str) -> str
         return OPENROUTER_DEFAULT_MODEL
     if provider_ref == DEEPSEEK_PROVIDER_REF:
         return DEEPSEEK_DEFAULT_MODEL
+    if provider_ref == CLOUDFLARE_PROVIDER_REF:
+        return CLOUDFLARE_DEFAULT_MODEL
     if provider_ref == ANTHROPIC_PROVIDER_REF:
         return ANTHROPIC_DEFAULT_MODEL
     return ""

--- a/praxist/core/cloudflare.py
+++ b/praxist/core/cloudflare.py
@@ -1,0 +1,83 @@
+"""Cloudflare Workers AI endpoint helpers.
+
+Workers AI exposes one OpenAI-compatible surface at
+``/client/v4/accounts/{account_id}/ai/v1`` and no Anthropic Messages route,
+so every Praxist path that talks to it reuses the OpenAI-compatible client
+and only varies the base URL and bearer credential.
+
+The account id is part of the URL rather than the credential, so it is
+resolved here once and shared by the CLI registry and the Codex relay.
+"""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Mapping
+
+CLOUDFLARE_PROVIDER = "cloudflare"
+"""Short provider name persisted as ``PRAXIST_LLM_PROVIDER``."""
+
+CLOUDFLARE_PROVIDER_REF = "model_provider:cloudflare"
+"""Canonical model-provider plugin ref for Workers AI."""
+
+CLOUDFLARE_API_FORMAT = "cloudflare_workers_ai"
+"""OpenAI-compatible wire format that keeps full ``@cf/vendor/model`` ids."""
+
+CLOUDFLARE_KEY_VAR = "CLOUDFLARE_API_KEY"
+"""Bearer credential variable for the Workers AI REST endpoint."""
+
+CLOUDFLARE_ACCOUNT_VAR = "CLOUDFLARE_ACCOUNT_ID"
+"""Account id variable interpolated into the Workers AI base URL."""
+
+CLOUDFLARE_BASE_URL_VAR = "CLOUDFLARE_BASE_URL"
+"""Explicit base-URL override that wins over account-id interpolation."""
+
+CLOUDFLARE_BASE_URL_TEMPLATE = "https://api.cloudflare.com/client/v4/accounts/{account_id}/ai/v1"
+"""OpenAI-compatible Workers AI base URL; ``/chat/completions`` hangs off it."""
+
+CLOUDFLARE_DEFAULT_MODEL = "@cf/deepseek-ai/deepseek-v4-flash-0731"
+"""Cheap/fast DeepSeek tier served by Workers AI."""
+
+CLOUDFLARE_STRONG_MODEL = "@cf/deepseek-ai/deepseek-v4-pro-0813"
+"""Strong-reasoner DeepSeek tier served by Workers AI."""
+
+
+def workers_ai_base_url(
+    env: Mapping[str, str] | None = None,
+    *,
+    account_id: str | None = None,
+) -> str:
+    """Return the Workers AI OpenAI-compatible base URL for this host.
+
+    Resolution order: an explicit ``account_id`` argument, then
+    ``CLOUDFLARE_BASE_URL`` as a whole-URL override, then
+    ``CLOUDFLARE_ACCOUNT_ID`` from the environment.
+    """
+    source = os.environ if env is None else env
+    explicit = (account_id or "").strip()
+    if explicit:
+        return CLOUDFLARE_BASE_URL_TEMPLATE.format(account_id=explicit)
+    override = str(source.get(CLOUDFLARE_BASE_URL_VAR, "")).strip().rstrip("/")
+    if override:
+        return override
+    resolved = str(source.get(CLOUDFLARE_ACCOUNT_VAR, "")).strip()
+    if not resolved:
+        raise ValueError(
+            f"{CLOUDFLARE_ACCOUNT_VAR} is not set; Workers AI base URLs are account-scoped. "
+            f"Export {CLOUDFLARE_ACCOUNT_VAR} or set {CLOUDFLARE_BASE_URL_VAR} to a full base URL."
+        )
+    return CLOUDFLARE_BASE_URL_TEMPLATE.format(account_id=resolved)
+
+
+__all__ = [
+    "CLOUDFLARE_ACCOUNT_VAR",
+    "CLOUDFLARE_API_FORMAT",
+    "CLOUDFLARE_BASE_URL_TEMPLATE",
+    "CLOUDFLARE_BASE_URL_VAR",
+    "CLOUDFLARE_DEFAULT_MODEL",
+    "CLOUDFLARE_KEY_VAR",
+    "CLOUDFLARE_PROVIDER",
+    "CLOUDFLARE_PROVIDER_REF",
+    "CLOUDFLARE_STRONG_MODEL",
+    "workers_ai_base_url",
+]

--- a/praxist/core/credentials.py
+++ b/praxist/core/credentials.py
@@ -55,6 +55,7 @@ class CredentialResolver:
             "model_provider:openai_compatible",
         ),
         ("DEEPSEEK_API_KEY", "model_provider", "deepseek_alias", "model_provider:deepseek_alias"),
+        ("CLOUDFLARE_API_KEY", "model_provider", "cloudflare", "model_provider:cloudflare"),
         (
             "SEMANTIC_SCHOLAR_API_KEY",
             "tool_server",

--- a/praxist/core/modeling.py
+++ b/praxist/core/modeling.py
@@ -8,6 +8,7 @@ from typing import Any
 
 import yaml
 
+from praxist.core.cloudflare import CLOUDFLARE_API_FORMAT
 from praxist.core.credentials import CredentialRef
 from praxist.core.protocol import ModelCallSpec, ModelProfile, ModelResult
 from praxist.core.registry import (
@@ -60,8 +61,13 @@ def normalize_model_for_provider(
 
 
 def _normalize_model_for_api_format(model: str, api_format: str) -> str:
-    """Strip a ``vendor/`` prefix when the api_format does not use one."""
-    if not model or api_format == "openrouter":
+    """Strip a ``vendor/`` prefix when the api_format does not use one.
+
+    ``cloudflare_workers_ai`` keeps the whole name: Workers AI model ids are
+    full ``@cf/vendor/model`` paths, so splitting on the first ``/`` would
+    corrupt them the same way it would corrupt an openrouter ``vendor/model``.
+    """
+    if not model or api_format in {"openrouter", CLOUDFLARE_API_FORMAT}:
         return model
     if "/" in model:
         return model.split("/", 1)[1]

--- a/praxist/plugins/agent_runtimes/codex_sdk/_relay.py
+++ b/praxist/plugins/agent_runtimes/codex_sdk/_relay.py
@@ -14,6 +14,12 @@ from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 from pathlib import Path
 
+from praxist.core.cloudflare import (
+    CLOUDFLARE_KEY_VAR,
+    CLOUDFLARE_PROVIDER,
+    workers_ai_base_url,
+)
+
 _PROVIDER_UPSTREAMS = {
     "deepseek": "https://api.deepseek.com/v1",
     "openrouter": "https://openrouter.ai/api/v1",
@@ -23,6 +29,8 @@ _PROVIDER_UPSTREAMS = {
     "mistral": "https://api.mistral.ai/v1",
     "groq": "https://api.groq.com/openai/v1",
     "xai": "https://api.x.ai/v1",
+    # Cloudflare is account-scoped and resolved at call time by
+    # ``provider_upstream``; it has no static entry here.
 }
 
 _PROVIDER_KEY_VARS = {
@@ -34,6 +42,7 @@ _PROVIDER_KEY_VARS = {
     "mistral": "MISTRAL_API_KEY",
     "groq": "GROQ_API_KEY",
     "xai": "XAI_API_KEY",
+    CLOUDFLARE_PROVIDER: CLOUDFLARE_KEY_VAR,
 }
 
 
@@ -77,6 +86,18 @@ def needs_relay(provider: str) -> bool:
     return provider not in {"", "openai"}
 
 
+def provider_upstream(provider: str) -> str | None:
+    """Return the OpenAI-compatible upstream base URL for a relay provider.
+
+    Cloudflare Workers AI is account-scoped, so its upstream is interpolated
+    from the environment rather than read from the static table.
+    """
+
+    if provider == CLOUDFLARE_PROVIDER:
+        return workers_ai_base_url()
+    return _PROVIDER_UPSTREAMS.get(provider)
+
+
 def provider_key_var(provider: str) -> str:
     """Return the credential environment variable for a provider."""
 
@@ -99,7 +120,10 @@ def start_relay(
         raise RuntimeError(
             "codex-relay is required for this model provider; install praxist[codex]"
         )
-    upstream = _PROVIDER_UPSTREAMS.get(provider)
+    try:
+        upstream = provider_upstream(provider)
+    except ValueError as exc:
+        raise RuntimeError(f"provider {provider!r} upstream is unavailable: {exc}") from exc
     if upstream is None:
         raise RuntimeError(f"Codex SDK relay does not support provider {provider!r}")
     if not api_key:
@@ -187,6 +211,7 @@ def _wait_for_listener(
 __all__ = [
     "RelayHandle",
     "needs_relay",
+    "provider_upstream",
     "provider_key_var",
     "provider_name",
     "start_relay",

--- a/praxist/plugins/agent_runtimes/codex_sdk/adapter.py
+++ b/praxist/plugins/agent_runtimes/codex_sdk/adapter.py
@@ -106,6 +106,7 @@ _MODEL_CREDENTIAL_ENV_KEYS = frozenset(
     {
         "ANTHROPIC_API_KEY",
         "ANTHROPIC_AUTH_TOKEN",
+        "CLOUDFLARE_API_KEY",
         "DASHSCOPE_API_KEY",
         "DEEPSEEK_API_KEY",
         "GROQ_API_KEY",

--- a/praxist/plugins/agent_runtimes/codex_sdk/plugin.yaml
+++ b/praxist/plugins/agent_runtimes/codex_sdk/plugin.yaml
@@ -24,6 +24,10 @@ runtime:
     - model_provider:openai_compatible
     - model_provider:openrouter
     - model_provider:deepseek_alias
+    # Cloudflare Workers AI is OpenAI-compatible and reaches this runtime
+    # through the codex relay; it has no Anthropic route, so it is
+    # deliberately absent from claude_sdk's allowlist.
+    - model_provider:cloudflare
   cache_strategy: runtime_auto_cache
   event_schema: praxist.agent_event.v1
   usage_reporting: usage_or_usage_unknown

--- a/praxist/plugins/model_providers/cloudflare/__init__.py
+++ b/praxist/plugins/model_providers/cloudflare/__init__.py
@@ -1,0 +1,1 @@
+"""Cloudflare Workers AI model provider plugin."""

--- a/praxist/plugins/model_providers/cloudflare/adapter.py
+++ b/praxist/plugins/model_providers/cloudflare/adapter.py
@@ -1,0 +1,11 @@
+"""Executable Cloudflare Workers AI model provider plugin."""
+
+from __future__ import annotations
+
+from praxist.core.cloudflare import CLOUDFLARE_API_FORMAT
+from praxist.core.modeling import ModelProviderAdapter
+
+
+def create_provider() -> ModelProviderAdapter:
+    """Manifest entrypoint for the Cloudflare Workers AI provider."""
+    return ModelProviderAdapter("model_provider:cloudflare", api_format=CLOUDFLARE_API_FORMAT)

--- a/praxist/plugins/model_providers/cloudflare/plugin.yaml
+++ b/praxist/plugins/model_providers/cloudflare/plugin.yaml
@@ -1,0 +1,40 @@
+schema_version: 1
+name: cloudflare
+kind: model_provider
+version: 0.1.0
+protocol_version: 1
+stability: experimental
+description: Cloudflare Workers AI OpenAI-compatible provider serving DeepSeek models.
+compatibility:
+  praxist_core: ">=0.1.0,<1.0"
+  python: ">=3.11"
+dependencies: []
+capabilities:
+  - provider.openai_compatible
+  - provider.cloudflare
+provider:
+  # Workers AI speaks OpenAI chat-completions at
+  # ``/client/v4/accounts/{account_id}/ai/v1`` and publishes no Anthropic
+  # Messages route, so this provider rides the OpenAI-compatible client and
+  # only swaps base URL + bearer token. The account id is part of the URL,
+  # not the credential, and is interpolated from CLOUDFLARE_ACCOUNT_ID by
+  # ``praxist.core.cloudflare.workers_ai_base_url``.
+  #
+  # ``cloudflare_workers_ai`` is a distinct api_format purely so model-name
+  # normalization keeps the full ``@cf/vendor/model`` id; the generic
+  # openai_compatible format strips everything before the first ``/`` and
+  # would turn ``@cf/deepseek-ai/deepseek-v4-flash-0731`` into
+  # ``deepseek-ai/deepseek-v4-flash-0731``, which Workers AI rejects.
+  api_format: cloudflare_workers_ai
+  default_model: "@cf/deepseek-ai/deepseek-v4-flash-0731"
+  cache_strategy: provider_default
+  usage_reporting: usage_or_usage_unknown
+  model_profiles:
+    cheap_peer: "@cf/deepseek-ai/deepseek-v4-flash-0731"
+    strong_reasoner: "@cf/deepseek-ai/deepseek-v4-pro-0813"
+  compatible_model_patterns:
+    - "@cf/*"
+entrypoint: adapter:create_provider
+code:
+  - adapter.py
+assets: []

--- a/praxist/plugins/workflow_stages/research_loop/backend/agent.py
+++ b/praxist/plugins/workflow_stages/research_loop/backend/agent.py
@@ -26,6 +26,12 @@ from praxist.config import (
     S3_RESULTS_PREFIX as _S3_RESULTS_PREFIX_DEFAULT,
 )
 from praxist.core.cache import build_cache_policy
+from praxist.core.cloudflare import (
+    CLOUDFLARE_ACCOUNT_VAR,
+    CLOUDFLARE_BASE_URL_VAR,
+    CLOUDFLARE_KEY_VAR,
+    CLOUDFLARE_PROVIDER_REF,
+)
 from praxist.core.credentials import CredentialRef, provider_name_from_ref
 from praxist.core.modeling import default_model_profile
 from praxist.core.prompt_layout import (
@@ -642,6 +648,16 @@ def _scoped_legacy_provider_env() -> dict[str, str]:
             "CLAUDE_CODE_EFFORT_LEVEL",
             "DEEPSEEK_API_KEY",
         )
+    elif provider_ref == CLOUDFLARE_PROVIDER_REF:
+        # Workers AI reaches the Codex runtime through the relay, which reads
+        # the bearer from CLOUDFLARE_API_KEY/OPENAI_API_KEY and interpolates
+        # the account-scoped upstream from CLOUDFLARE_ACCOUNT_ID.
+        allowed = (
+            CLOUDFLARE_KEY_VAR,
+            "OPENAI_API_KEY",
+            CLOUDFLARE_ACCOUNT_VAR,
+            CLOUDFLARE_BASE_URL_VAR,
+        )
     elif provider_ref == "model_provider:fake_provider":
         allowed = ()
     else:
@@ -675,6 +691,11 @@ def _scoped_legacy_provider_env() -> dict[str, str]:
             if provider_ref == "model_provider:openrouter" and var == "ANTHROPIC_BASE_URL":
                 val = normalize_openrouter_base_url(val)
             env[var] = val
+    if provider_ref == CLOUDFLARE_PROVIDER_REF:
+        cloudflare_key = os.environ.get(CLOUDFLARE_KEY_VAR, "")
+        if cloudflare_key:
+            env[CLOUDFLARE_KEY_VAR] = cloudflare_key
+            env["OPENAI_API_KEY"] = cloudflare_key
     if provider_ref == "model_provider:deepseek_alias":
         deepseek_key = os.environ.get("DEEPSEEK_API_KEY", "")
         if deepseek_key:

--- a/praxist/plugins/workflow_stages/research_loop/provider_env.py
+++ b/praxist/plugins/workflow_stages/research_loop/provider_env.py
@@ -4,6 +4,12 @@ from __future__ import annotations
 
 from collections.abc import Mapping
 
+from praxist.core.cloudflare import (
+    CLOUDFLARE_KEY_VAR,
+    CLOUDFLARE_PROVIDER_REF,
+    workers_ai_base_url,
+)
+
 OPENROUTER_CLAUDE_SDK_BASE_URL = "https://openrouter.ai/api"
 OPENROUTER_OPENAI_COMPAT_BASE_URL = "https://openrouter.ai/api/v1"
 DEEPSEEK_CLAUDE_SDK_BASE_URL = "https://api.deepseek.com/anthropic"
@@ -43,7 +49,20 @@ def freeze_provider_env(model_provider_ref: str, env: Mapping[str, str]) -> dict
         "OPENROUTER_API_KEY": None,
         "OPENAI_API_KEY": None,
         "DEEPSEEK_API_KEY": None,
+        CLOUDFLARE_KEY_VAR: None,
+        "CLOUDFLARE_BASE_URL": None,
     }
+    if model_provider_ref == CLOUDFLARE_PROVIDER_REF:
+        # Workers AI is OpenAI-compatible only. The Codex relay reads the
+        # key from OPENAI_API_KEY and the base URL from CLOUDFLARE_BASE_URL,
+        # so both are frozen here and the Anthropic surface stays unset.
+        auth_token = env.get(CLOUDFLARE_KEY_VAR)
+        return {
+            **base,
+            CLOUDFLARE_KEY_VAR: auth_token,
+            "OPENAI_API_KEY": auth_token,
+            "CLOUDFLARE_BASE_URL": workers_ai_base_url(env),
+        }
     if model_provider_ref == "model_provider:openrouter":
         base_url = normalize_openrouter_base_url(
             env.get("ANTHROPIC_BASE_URL")

--- a/praxist/plugins/workflow_stages/research_loop/stage.py
+++ b/praxist/plugins/workflow_stages/research_loop/stage.py
@@ -10,6 +10,11 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
+from praxist.core.cloudflare import (
+    CLOUDFLARE_KEY_VAR,
+    CLOUDFLARE_PROVIDER_REF,
+    workers_ai_base_url,
+)
 from praxist.core.ledgers import BudgetLedger
 from praxist.core.role_skills import RoleSkill, load_role_skill
 from praxist.core.runtimes import close_runtime_for_ref, collect_runtime_usage
@@ -469,6 +474,8 @@ def _provider_env(model_provider_ref: str) -> dict[str, str | None]:
         "OPENROUTER_API_KEY": None,
         "OPENAI_API_KEY": None,
         "DEEPSEEK_API_KEY": None,
+        CLOUDFLARE_KEY_VAR: None,
+        "CLOUDFLARE_BASE_URL": None,
         "ANTHROPIC_MODEL": None,
         "ANTHROPIC_DEFAULT_OPUS_MODEL": None,
         "ANTHROPIC_DEFAULT_SONNET_MODEL": None,
@@ -476,6 +483,15 @@ def _provider_env(model_provider_ref: str) -> dict[str, str | None]:
         "CLAUDE_CODE_SUBAGENT_MODEL": None,
         "CLAUDE_CODE_EFFORT_LEVEL": None,
     }
+    if model_provider_ref == CLOUDFLARE_PROVIDER_REF:
+        # Workers AI is OpenAI-compatible only; see provider_env.freeze_provider_env.
+        auth_token = os.environ.get(CLOUDFLARE_KEY_VAR)
+        return {
+            **base,
+            CLOUDFLARE_KEY_VAR: auth_token,
+            "OPENAI_API_KEY": auth_token,
+            "CLOUDFLARE_BASE_URL": workers_ai_base_url(os.environ),
+        }
     if model_provider_ref == "model_provider:openrouter":
         auth_token = os.environ.get("ANTHROPIC_AUTH_TOKEN") or os.environ.get("OPENROUTER_API_KEY")
         base_url = normalize_openrouter_base_url(


### PR DESCRIPTION
## Summary

Adds a `cloudflare` model provider so Praxist can run peers against Cloudflare
Workers AI, plus the two runtime-side fixes that provider turned out to require.

Workers AI exposes one OpenAI-compatible surface at
`https://api.cloudflare.com/client/v4/accounts/{CLOUDFLARE_ACCOUNT_ID}/ai/v1`
and publishes no Anthropic Messages route, so the plugin rides the existing
OpenAI-compatible client and only swaps the base URL and the bearer credential
(`CLOUDFLARE_API_KEY`). The account id is part of the URL rather than the
credential, so it is interpolated once in `praxist/core/cloudflare.py` and
shared by the CLI registry, the Codex relay, and the research-loop stage.
`CLOUDFLARE_BASE_URL` overrides the whole URL when an operator needs it.

Model ids are full `@cf/vendor/model` paths (`@cf/deepseek-ai/deepseek-v4-flash-0731`,
`@cf/zai-org/glm-5.3-flash`). That is why the plugin declares a distinct
`cloudflare_workers_ai` api_format instead of reusing `openai_compatible`: the
generic format strips everything before the first `/` during model-name
normalization, which would rewrite `@cf/deepseek-ai/deepseek-v4-flash-0731` to
`deepseek-ai/deepseek-v4-flash-0731` — a name Workers AI rejects. The format is
handled exactly like `openrouter` in `_normalize_model_for_api_format`; it
changes nothing else about the wire protocol.

The provider is selectable through the normal `configure-llm` path
(`PROVIDER_KEY_MAP` / `PROVIDER_REF_FOR_SHORT_NAME` / `CredentialResolver`), with
`@cf/deepseek-ai/deepseek-v4-flash-0731` as `cheap_peer` and
`@cf/deepseek-ai/deepseek-v4-pro-0813` as `strong_reasoner`.

### The two runtime fixes

Both were required to make the provider usable, and both surfaced only at
`resolve`/`start` time — `praxist doctor` passed while neither was in place, so
they are included here rather than split out:

1. **`codex_sdk` allowlist** (`plugins/agent_runtimes/codex_sdk/plugin.yaml`) —
   `compatible_model_providers` did not list `model_provider:cloudflare`, so
   runtime resolution rejected the pairing even though Workers AI reaches the
   Codex runtime through the ordinary relay. `claude_sdk` is deliberately *not*
   extended: Workers AI has no Anthropic route.
2. **Credential forwarding** (`workflow_stages/research_loop/backend/agent.py`,
   `provider_env.py`, `stage.py`) — `_scoped_legacy_provider_env` had no
   `cloudflare` branch, so the key and account id were scrubbed out of the peer
   subprocess environment and the relay started unauthenticated. The new branch
   forwards `CLOUDFLARE_API_KEY` (also mirrored to `OPENAI_API_KEY`, which is
   what the relay reads), `CLOUDFLARE_ACCOUNT_ID`, and `CLOUDFLARE_BASE_URL`,
   and leaves the Anthropic surface unset. `freeze_provider_env` and
   `_provider_env` gained matching entries so the variables are explicitly
   nulled for every other provider rather than leaking across a switch.

## Scope

- **Commits:** `8dd890f` (provider), `b7dfc9e` (codex_sdk allowlist),
  `e904864` (credential forwarding), `e49c2a2` (docs).
- **Affected modules:** new `praxist/core/cloudflare.py`; new
  `praxist/plugins/model_providers/cloudflare/`; touched `praxist/cli/_env.py`,
  `praxist/cli/start.py`, `praxist/core/credentials.py`,
  `praxist/core/modeling.py`, `praxist/plugins/agent_runtimes/codex_sdk/`
  (`_relay.py`, `adapter.py`, `plugin.yaml`), and
  `praxist/plugins/workflow_stages/research_loop/` (`backend/agent.py`,
  `provider_env.py`, `stage.py`).
- **Public contracts:** additive. One new `api_format` value
  (`cloudflare_workers_ai`), one new provider ref (`model_provider:cloudflare`),
  three new environment variables. `_relay.py` gains an exported
  `provider_upstream()` helper because Cloudflare's upstream cannot live in the
  static `_PROVIDER_UPSTREAMS` table; existing table entries are unchanged.
- **Compatibility:** no existing provider, runtime, or env var changes behavior.
  A missing `CLOUDFLARE_ACCOUNT_ID` raises a named `ValueError` explaining which
  variable to set, surfaced as a `RuntimeError` from `start_relay`.
- **Task-agnostic rationale:** the provider is a transport, and both fixes are
  gaps in shared provider plumbing that any OpenAI-compatible, account-scoped
  provider would hit.

## Verification

Run on macOS 27.0 (arm64), Praxist 0.5.0, `codex_sdk` runtime via the relay:

- `praxist doctor --target claude` — clean.
- Real generations completed through the relay (HTTP 200) against
  `@cf/deepseek-ai/deepseek-v4-flash-0731` and `@cf/zai-org/glm-5.3-flash`.
- Test suite: 37 failures on this branch vs 41 on the `main` baseline
  (`aa198d0`). Every remaining delta was reviewed; the one difference not
  explained by the baseline is a timing flake, confirmed by re-running it.
- `ruff` clean.

**Not verified, and deliberately called out:**

- Only single-generation runs were exercised. Multi-generation behavior with
  this provider is unproven.
- Under a long multi-peer run, streaming hit one reconnect. It recovered and the
  run continued, but the cause was not root-caused, so I would not claim the
  streaming path is production-hardened on this route yet.
- No new unit tests are included in these commits. The behavior was validated
  end-to-end against the live endpoint rather than in the test suite; happy to
  add focused tests for `workers_ai_base_url` resolution order,
  `_normalize_model_for_api_format` on `@cf/...` ids, and the
  `_scoped_legacy_provider_env` cloudflare branch if you want them in this PR.

## Checklist

- [x] The change is focused and does not include unrelated generated files.
- [ ] Tests cover the affected behavior. — see the note above; validated
      end-to-end against the live endpoint, unit tests not yet written.
- [x] Documentation, templates, examples, and skills were updated where needed.
      (`docs/guides/model-providers.md`, `docs/guides/agent-runtimes.md`,
      `docs/reference/plugins.md`.)
- [x] No credentials, private task data, or research-run artifacts are included.
- [x] New dependencies and copied assets include their source and license terms.
      (No new dependencies; the provider reuses the existing OpenAI-compatible
      client.)
- [x] I have read `.github/CONTRIBUTING.md` and the contribution terms in `LICENSE.md`.
