### PR TITLE
Handle daemon ps rows without elapsed time

### DIFF
--- a/praxist/cli/status.py
+++ b/praxist/cli/status.py
@@ -76,6 +76,7 @@ STATE_FAILED = "failed"
 STATE_INCONSISTENT = "status_inconsistent"
 
 _RUN_DIR_HINT_RE = re.compile(r"--run-dir(?:[=\s]+)(\S+)")
+_PS_ETIME_RE = re.compile(r"^(?:-|\d{1,2}:\d{2}(?::\d{2})?|\d+-\d{1,2}:\d{2}:\d{2})$")
 _LAST_PS_ERROR = ""
 
 
@@ -814,18 +815,28 @@ def _read_ps_table(*, timeout_seconds: float = 10.0) -> dict[int, tuple[int, str
     rows: dict[int, tuple[int, str, str]] = {}
     lines = result.stdout.splitlines()
     for line in lines[1:]:
-        parts = line.strip().split(None, 3)
-        if len(parts) < 4:
+        parts = line.strip().split(None, 2)
+        if len(parts) < 3:
             continue
         try:
             pid = int(parts[0])
             ppid = int(parts[1])
         except ValueError:
             continue
-        etime = parts[2]
-        command = parts[3]
+        etime, command = _split_ps_etime_command(parts[2])
+        if not command:
+            continue
         rows[pid] = (ppid, etime, command)
     return rows
+
+
+def _split_ps_etime_command(remainder: str) -> tuple[str, str]:
+    fields = remainder.strip().split(None, 1)
+    if not fields:
+        return "-", ""
+    if _PS_ETIME_RE.match(fields[0]):
+        return fields[0], fields[1] if len(fields) > 1 else ""
+    return "-", remainder.strip()
 
 
 def _self_ancestor_pids(rows: dict[int, tuple[int, str, str]]) -> set[int]:

--- a/tests/unit/test_cli_status.py
+++ b/tests/unit/test_cli_status.py
@@ -314,6 +314,45 @@ class StatusMergeTest(unittest.TestCase):
         self.assertEqual(row.model, "claude-opus-4-7")
         self.assertEqual(row.state, "running")
 
+    def test_daemonized_registry_row_with_missing_etime_stays_live(self) -> None:
+        from praxist.cli import status
+
+        run_id = self._seed_registry(
+            command=(
+                "python",
+                "-m",
+                "praxist.run",
+                "run",
+                "--task-path",
+                "/t",
+                "--run-dir",
+                "/tmp/status_demo",
+            ),
+        )
+        ps_output = (
+            "    PID    PPID  ELAPSED COMMAND\n"
+            "   8000       0 python -m praxist.run run --task-path /t --run-dir /tmp/status_demo\n"
+        )
+        with (
+            patch("praxist.cli.status.shutil.which", return_value="/bin/ps"),
+            patch(
+                "praxist.cli.status.subprocess.run",
+                return_value=_fake_ps_completed(ps_output),
+            ),
+            patch.object(os, "getpid", return_value=99998),
+            patch.object(os, "getppid", return_value=99999),
+        ):
+            rows = status.collect_status_rows(include_peer_health=False)
+
+        self.assertEqual(len(rows), 1)
+        row = rows[0]
+        self.assertEqual(row.run_id, run_id)
+        self.assertEqual(row.source, status.SOURCE_REGISTRY)
+        self.assertEqual(row.state, "running")
+        self.assertEqual(row.ppid, 0)
+        self.assertEqual(row.etime, "-")
+        self.assertIn("python -m praxist.run", row.command)
+
     def test_live_process_with_stopped_registry_is_inconsistent(self) -> None:
         from praxist.cli import registry, status
 


### PR DESCRIPTION
## Summary

- Handles `ps` rows where a daemonized Praxist controller is present with `ppid=0` but the elapsed-time field is missing.
- Preserves the command string instead of shifting it left and making registry command validation mark the run as stale.
- Adds a regression test for the daemonized registry-row shape reported in #82.

Closes #82.

## Verification

```bash
python -m unittest tests.unit.test_cli_status.StatusMergeTest.test_daemonized_registry_row_with_missing_etime_stays_live -q
python -m unittest tests.unit.test_cli_status -q
python -m unittest tests.unit.test_cli_start tests.unit.test_cli_resume tests.unit.test_cli_monitor -q
python -m compileall -q praxist/cli/status.py tests/unit/test_cli_status.py
uv run pyrefly check praxist/cli/status.py
uv run ruff check praxist/cli/status.py tests/unit/test_cli_status.py
uv run ruff format --check praxist/cli/status.py tests/unit/test_cli_status.py
git diff --check
```

