### PR TITLE
docs: add good first contribution guidance

### DIFF
--- a/docs/guides/contributing.md
+++ b/docs/guides/contributing.md
@@ -60,3 +60,28 @@ run artifact schemas.
 
 Those changes should include focused tests and, when they change architecture
 contracts, a concise rationale in the pull-request description.
+## Good First Contributions
+
+If you are making your first contribution, prefer small changes with a
+well-defined boundary and straightforward verification.
+
+Good starter contributions include:
+
+- graduating one small file from Pyrefly excludes;
+- adding focused tests around existing contracts;
+- improving generated-reference consistency checks;
+- fixing documentation links or wording while respecting the one-fact-one-owner
+  policy;
+- adding plugin-local tests for existing generic plugins.
+
+Avoid using a first contribution to change high-risk architecture surfaces,
+including:
+
+- startup semantics;
+- credential selection;
+- runtime invocation;
+- resume boundaries;
+- workflow-stage behavior.
+
+When in doubt, choose the smallest change that can be verified independently
+and keep the change within its existing repository boundary.


### PR DESCRIPTION
## Summary

Add contributor guidance for choosing safe, scoped first contributions.

The new section identifies low-risk contribution areas and highlights
high-risk architecture areas that new contributors should avoid.

## Scope

- Affected file: `docs/guides/contributing.md`
- No code or runtime behavior is changed.
- No new dependencies are introduced.
- The guidance follows the repository's existing contribution boundaries.

## Verification

- `git diff --check`
- Documentation build: `uv run python scripts/build_docs_site.py`

## Checklist

- [x] The change is focused and does not include unrelated generated files.
- [x] Documentation was updated where needed.
- [x] No credentials, private task data, or research-run artifacts are included.
- [x] No new dependencies are introduced.
- [x] I have read `.github/CONTRIBUTING.md` and the contribution terms in `LICENSE.md`.