### PR TITLE
Fix #82: Handle daemonized process start time parsing

### DIFF
--- a/praxist/cli/registry.py
+++ b/praxist/cli/registry.py
@@ -401,7 +401,7 @@ def process_start_token(pid: int) -> str:
     except (OSError, subprocess.TimeoutExpired):
         return ""
     started = " ".join(result.stdout.split())
-    if result.returncode == 0 and started:
+    if result.returncode == 0 and started and started != "-":
         return f"ps:{started}"
     return ""
 

--- a/tests/unit/test_cli_registry.py
+++ b/tests/unit/test_cli_registry.py
@@ -309,6 +309,27 @@ class RegistryBasicsTest(unittest.TestCase):
             env={"LANG": "C", "LC_ALL": "C"},
         )
 
+    def test_process_start_token_handles_daemonized_dash(self) -> None:
+        from praxist.cli import registry
+
+        with (
+            patch.object(Path, "read_text", side_effect=OSError("proc unavailable")),
+            patch("praxist.cli.registry.shutil.which", return_value="/bin/ps"),
+            patch(
+                "praxist.cli.registry.subprocess.run",
+                return_value=registry.subprocess.CompletedProcess(
+                    args=[],
+                    returncode=0,
+                    stdout="-\n",
+                    stderr="",
+                ),
+            ) as run,
+        ):
+            self.assertEqual(
+                registry.process_start_token(4242),
+                "",
+            )
+
     def test_process_start_token_handles_proc_no_ps_and_ps_timeout(self) -> None:
         from praxist.cli import registry
 

--- a/tests/unit/test_cli_registry.py
+++ b/tests/unit/test_cli_registry.py
@@ -321,9 +321,8 @@ class RegistryBasicsTest(unittest.TestCase):
                     args=[],
                     returncode=0,
                     stdout="-\n",
-                    stderr="",
                 ),
-            ) as run,
+            ),
         ):
             self.assertEqual(
                 registry.process_start_token(4242),


### PR DESCRIPTION
Fixes #82. Updates `process_start_token` in `praxist/cli/registry.py` to handle the `-` case and return an empty string when `ps -o lstart=` outputs `-` for daemonized processes. This allows `process_identity_matches` to fail gracefully and fall back to matching the command line flags, preventing active processes from being incorrectly marked as `stale`.