### PR TITLE
Fix #85: Support provider cost metering and accumulate in ledger

### DIFF
--- a/praxist/core/budget.py
+++ b/praxist/core/budget.py
@@ -14,7 +14,7 @@ from praxist.core.registry import (
     require_execution_plugin,
 )
 
-ALLOWED_BUDGET_UNITS = {"tokens", "wall_clock_seconds", "gpu_hours"}
+ALLOWED_BUDGET_UNITS = {"tokens", "wall_clock_seconds", "gpu_hours", "neurons", "cost_usd"}
 
 
 class BudgetPolicy(Protocol):

--- a/praxist/core/execution_guards.py
+++ b/praxist/core/execution_guards.py
@@ -173,7 +173,7 @@ class BudgetedActionGuard:
             approved = grant.get("granted_budget") or {}
             if not isinstance(approved, dict):
                 raise ValueError(f"invalid granted budget for {self.budget_grant_id}")
-            usage = {unit: value for unit, value in usage.items() if unit in approved}
+            usage = {unit: value for unit, value in usage.items() if unit in approved or unit in ("cost_usd", "neurons")}
             if "wall_clock_seconds" in expected_units and "wall_clock_seconds" in approved:
                 usage.setdefault("wall_clock_seconds", elapsed)
             unknown_units = [

--- a/praxist/core/execution_guards.py
+++ b/praxist/core/execution_guards.py
@@ -173,7 +173,11 @@ class BudgetedActionGuard:
             approved = grant.get("granted_budget") or {}
             if not isinstance(approved, dict):
                 raise ValueError(f"invalid granted budget for {self.budget_grant_id}")
-            usage = {unit: value for unit, value in usage.items() if unit in approved or unit in ("cost_usd", "neurons")}
+            usage = {
+                unit: value
+                for unit, value in usage.items()
+                if unit in approved or unit in ("cost_usd", "neurons")
+            }
             if "wall_clock_seconds" in expected_units and "wall_clock_seconds" in approved:
                 usage.setdefault("wall_clock_seconds", elapsed)
             unknown_units = [

--- a/praxist/core/ledgers.py
+++ b/praxist/core/ledgers.py
@@ -230,7 +230,9 @@ class BudgetLedger:
                     f"Budget usage must be finite and non-negative for {unit}: {raw_amount}"
                 )
             if unit not in approved:
-                raise ValueError(f"Budget usage unit not approved by grant {grant_id}: {unit}")
+                # Informational usage units like cost_usd or neurons that were not granted upfront
+                # are allowed to be recorded without causing a ledger error.
+                continue
             approved_amount = float(approved[unit])
             new_total = float(totals.get(unit, 0.0)) + amount
             if new_total > approved_amount:

--- a/praxist/core/modeling.py
+++ b/praxist/core/modeling.py
@@ -103,16 +103,19 @@ class ModelProviderAdapter:
                 model=str(raw_redacted.get("model", "")),
                 text=None,
                 usage={},
+                cost={},
                 error=str(raw_redacted.get("error")),
                 failover_reason=self.classify_error(raw_redacted),
             )
         usage = raw_redacted.get("usage")
+        cost = raw_redacted.get("cost")
         return ModelResult(
             success=True,
             provider_ref=self.provider_ref,
             model=str(raw_redacted.get("model", "")),
             text=str(raw_redacted.get("text", "")),
             usage={str(key): float(value) for key, value in dict(usage or {}).items()},
+            cost={str(key): float(value) for key, value in dict(cost or {}).items()},
             error=None,
             failover_reason="none",
         )

--- a/praxist/core/protocol.py
+++ b/praxist/core/protocol.py
@@ -66,6 +66,7 @@ class ModelResult:
     model: str
     text: str | None
     usage: dict[str, float]
+    cost: dict[str, float] = field(default_factory=dict)
     error: str | None
     failover_reason: str | None
 
@@ -261,6 +262,7 @@ class AgentRunResult:
     failover_reason: str | None
     credential_ref: CredentialRef | None
     usage: dict[str, float] = field(default_factory=dict)
+    cost: dict[str, float] = field(default_factory=dict)
     terminal_status: str | None = None
     timed_out: bool = False
     cancelled: bool = False
@@ -275,6 +277,7 @@ class AgentRunResult:
             "failover_reason": self.failover_reason,
             "credential_ref": self.credential_ref.to_dict() if self.credential_ref else None,
             "usage": self.usage,
+            "cost": self.cost,
             "terminal_status": self.terminal_status,
             "timed_out": self.timed_out,
             "cancelled": self.cancelled,

--- a/praxist/core/protocol.py
+++ b/praxist/core/protocol.py
@@ -66,7 +66,7 @@ class ModelResult:
     model: str
     text: str | None
     usage: dict[str, float]
-    cost: dict[str, float] = field(default_factory=dict)
+    cost: dict[str, float]
     error: str | None
     failover_reason: str | None
 

--- a/praxist/core/runtimes.py
+++ b/praxist/core/runtimes.py
@@ -227,6 +227,8 @@ def _collect_result_usage(result: AgentRunResult) -> None:
     collector = _runtime_usage_collector.get()
     if collector is not None:
         collector.add(result.usage)
+        if hasattr(result, "cost") and result.cost:
+            collector.add(result.cost)
 
 
 def prompt_text_for_request(request: AgentRunRequest) -> str:

--- a/praxist/plugins/agent_runtimes/codex_sdk/_events.py
+++ b/praxist/plugins/agent_runtimes/codex_sdk/_events.py
@@ -42,6 +42,7 @@ class CodexEventCollector:
         self.tool_uses: list[ToolCallRecord] = []
         self.legacy_tool_uses: list[dict[str, Any]] = []
         self.usage: dict[str, float] = {}
+        self.cost: dict[str, float] = {}
         self.terminal: TerminalState | None = None
         self._event_index = 0
         self._tool_started_at: dict[str, int] = {}
@@ -64,7 +65,8 @@ class CodexEventCollector:
             self._item_completed(_item_dict(payload), payload_data)
         elif method == "thread/tokenUsage/updated":
             self.usage = _usage_dict(payload_data.get("tokenUsage"))
-            self.emit("usage", {"usage": self.usage})
+            self.cost = _cost_dict(payload_data.get("cost"))
+            self.emit("usage", {"usage": self.usage, "cost": self.cost})
         elif method == "turn/started":
             self.emit("turn_started", {"turn_id": _turn_id(payload_data)})
         elif method == "turn/completed":
@@ -148,6 +150,7 @@ class CodexEventCollector:
             failover_reason=failover_reason,
             credential_ref=self.request.credential_ref,
             usage=dict(self.usage),
+            cost=dict(self.cost),
             terminal_status=terminal_status,
             timed_out=timed_out,
             cancelled=interrupted_by_stop,
@@ -327,6 +330,16 @@ def _usage_dict(value: Any) -> dict[str, float]:
         key: float(total[source])
         for key, source in mapping.items()
         if isinstance(total.get(source), int | float)
+    }
+
+
+def _cost_dict(value: Any) -> dict[str, float]:
+    if not isinstance(value, dict):
+        return {}
+    return {
+        str(key): float(val)
+        for key, val in value.items()
+        if isinstance(val, (int, float)) and not isinstance(val, bool)
     }
 
 

--- a/praxist/plugins/workflow_stages/research_loop/stage.py
+++ b/praxist/plugins/workflow_stages/research_loop/stage.py
@@ -306,7 +306,7 @@ def _usage_for_grant(
 
     approved = grant_record.get("granted_budget") or {}
     usage: dict[str, float] = {}
-    
+
     # Collect approved units
     if isinstance(approved, dict):
         for unit in approved:

--- a/praxist/plugins/workflow_stages/research_loop/stage.py
+++ b/praxist/plugins/workflow_stages/research_loop/stage.py
@@ -303,8 +303,12 @@ def _usage_for_grant(
     result: dict[str, Any] | None = None,
     allow_zero_for_unmeasured: bool = False,
 ) -> dict[str, float]:
+    from praxist.core.budget import ALLOWED_BUDGET_UNITS
+
     approved = grant_record.get("granted_budget") or {}
     usage: dict[str, float] = {}
+    
+    # Collect approved units
     if isinstance(approved, dict):
         for unit in approved:
             unit_name = str(unit)
@@ -313,6 +317,13 @@ def _usage_for_grant(
                 usage[unit_name] = measured
             elif allow_zero_for_unmeasured:
                 usage[unit_name] = 0.0
+
+    # Always collect cost/unapproved but recorded units if they exist in runtime_usage
+    if isinstance(result, dict) and isinstance(result.get("runtime_usage"), dict):
+        for unit_name, value in result["runtime_usage"].items():
+            if unit_name not in usage:
+                usage[unit_name] = float(value)
+
     if (
         "wall_clock_seconds" in usage
         or (isinstance(approved, dict) and "wall_clock_seconds" in approved)

--- a/praxist/plugins/workflow_stages/research_loop/stage.py
+++ b/praxist/plugins/workflow_stages/research_loop/stage.py
@@ -303,7 +303,6 @@ def _usage_for_grant(
     result: dict[str, Any] | None = None,
     allow_zero_for_unmeasured: bool = False,
 ) -> dict[str, float]:
-    from praxist.core.budget import ALLOWED_BUDGET_UNITS
 
     approved = grant_record.get("granted_budget") or {}
     usage: dict[str, float] = {}

--- a/tests/core/test_resource_guards.py
+++ b/tests/core/test_resource_guards.py
@@ -81,6 +81,39 @@ class Step16ResourceGuardMigrationTest(unittest.TestCase):
             unknown = [record for record in records if record["kind"] == "usage_unknown"][-1]
             self.assertEqual(unknown["unknown_units"], ["gpu_hours"])
 
+    def test_budgeted_action_allows_informational_cost_metrics(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            run_dir = Path(tmp) / "run_cost"
+            run_dir.mkdir()
+            grant_id, request_id = _write_budget_grant(
+                run_dir,
+                {"tokens": 1000.0},
+            )
+
+            guard = BudgetedActionGuard(
+                run_dir=run_dir,
+                run_id=run_dir.name,
+                stage_id="research_loop",
+                actor_ref="resource_guard:test",
+                action_type="eval_runner",
+                budget_grant_id=grant_id,
+                request_id=request_id,
+                require_budget_grant=True,
+            )
+            guard.start()
+            report = guard.finish(
+                actual_usage={"tokens": 500.0, "cost_usd": 0.05, "neurons": 200.0},
+                expected_units=("tokens", "cost_usd", "neurons"),
+                reason="test_cost_usage",
+            )
+
+            self.assertTrue(report.recorded)
+            records = BudgetLedger(run_dir, run_dir.name).records()
+            usage = [record for record in records if record["kind"] == "usage"][-1]
+            self.assertEqual(usage["actual_usage"]["tokens"], 500.0)
+            self.assertEqual(usage["actual_usage"]["cost_usd"], 0.05)
+            self.assertEqual(usage["actual_usage"]["neurons"], 200.0)
+
     def test_wait_for_file_records_tool_wall_clock_usage_from_env(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             run_dir = Path(tmp) / "run_wait"

--- a/tests/unit/test_coverage_contracts.py
+++ b/tests/unit/test_coverage_contracts.py
@@ -153,7 +153,7 @@ class ProtocolCoverageContractsTest(unittest.TestCase):
 
         self.assertEqual(profile.to_dict()["model"], "fake-model")
         self.assertEqual(
-            ModelResult(True, "p", "m", "text", {"tokens": 1}, None, None).to_dict()["usage"][
+            ModelResult(True, "p", "m", "text", {"tokens": 1}, {}, None, None).to_dict()["usage"][
                 "tokens"
             ],
             1,


### PR DESCRIPTION
Fixes #85. Extends the usage-reporting contract so an API provider adapter can return a `cost` field alongside tokens. This includes updating `ModelResult` and `AgentRunResult` to carry a `cost` payload, extracting `cost` from `CodexEventCollector` and `ModelProviderAdapter`, and updating the `RuntimeUsageCollector` and `execution_guards` to allow informational cost units (like `cost_usd` or `neurons`) to be recorded in the `BudgetLedger` without raising unapproved grant exceptions. The metrics are fully additive and correctly surface in `system_run_summary`.