### PR TITLE
docs: add good first contribution guidance for new contributors. Clos…

### DIFF
--- a/docs/guides/contributing.md
+++ b/docs/guides/contributing.md
@@ -10,6 +10,30 @@ task projects physically separate.
 - `docs/concepts/architecture.md` is the active architecture overview.
 - `docs/index.md` is the source documentation entry.
 
+## Good First Contributions
+
+New contributors who are not yet familiar with the system's architecture are encouraged to start with well-scoped, low-risk changes. The following areas are suitable for a first contribution, particularly when no open issues are available.
+
+### Recommended starter lanes
+
+- **Graduate one small file from Pyrefly excludes**: Identify a file currently excluded from Pyrefly static checks, address the underlying issues, and re-enable checking.
+- **Add focused tests around existing contracts**: Improve test coverage for a specific module or function without altering its behavior.
+- **Improve generated-reference consistency checks**: Enhance the tooling that verifies cross-references in the documentation.
+- **Fix documentation links or wording**: Correct broken links or improve clarity, while respecting the one-fact-one-owner policy.
+- **Add plugin-local tests for existing generic plugins**: Write tests that verify plugin behavior in isolation.
+
+### Areas to avoid for first contributions
+
+The following areas involve core architectural surfaces and require deep system understanding. They are not recommended for first-time contributors:
+
+- Startup semantics
+- Credential selection
+- Runtime invocation
+- Resume boundaries
+- Workflow-stage behavior
+
+For a detailed explanation of these and other high-risk areas, refer to the [What Requires Extra Care](#what-requires-extra-care) section below.
+
 ## Default Change Flow
 
 1. Identify whether the change belongs to core, a generic plugin, a task template,


### PR DESCRIPTION
## Summary

The contributing guide currently explains the overall process and high-risk areas, but does not provide new contributors with a short, explicit list of safe starting points when no open issues are assigned. This PR adds a concise "Good First Contributions" section to `docs/guides/contributing.md`, recommending low-risk starter lanes and clearly identifying areas to avoid. The change is minimal, non‑functional, and only improves discoverability.

## Scope

- Affected modules or public contracts: None – only documentation.
- Compatibility considerations: None.
- Task-agnostic rationale, when shared Praxist behavior changes: Not applicable (no code changes).

## Verification

Documentation-only change; no tests required. The new section renders correctly and the internal anchor link is valid.

## Checklist

- [x] The change is focused and does not include unrelated generated files.
- [x] Tests cover the affected behavior. *(N/A – documentation only, but the section is verified to render correctly.)*
- [x] Documentation, templates, examples, and skills were updated where needed. *(Only the contributing guide is updated.)*
- [x] No credentials, private task data, or research-run artifacts are included.
- [x] New dependencies and copied assets include their source and license terms. *(N/A)*
- [x] I have read `.github/CONTRIBUTING.md` and the contribution terms in `LICENSE.md`.

Closes #45 