### PR TITLE
docs: clarify workflow stage placeholder guidance

### DIFF
--- a/docs/guides/workflow-stages.md
+++ b/docs/guides/workflow-stages.md
@@ -24,6 +24,14 @@ cohort. See [Research Topology Audit API](research-topology-and-module-api.md).
 registered interface placeholders, not product modules. They remain disabled
 by default and do not provide ideation or paper-writing workflows.
 
+Do not implement behavior for these placeholders as an isolated or casual
+contribution. Before either stage becomes a supported workflow, a design
+proposal should define its expected artifacts, lifecycle, budget behavior,
+and test/conformance requirements.
+
+Executable stage semantics belong in Python workflow plugins and should include
+the corresponding conformance coverage.
+
 ## Local Reviewer
 
 `workflow_stage:reviewer_stub` provides an optional local artifact and


### PR DESCRIPTION
## Summary

- clarify that ideation and paper-writing workflow stages are interface placeholders
- document that implementation requires a design proposal first
- define the expected artifacts, lifecycle, budget, and conformance considerations

Closes #44

## Scope

- Documentation-only change to `docs/guides/workflow-stages.md`
- No workflow-stage implementation or runtime behavior changed

## Verification

- `git diff --check` passed
- Reviewed the resulting documentation diff

## Checklist

- [x] The change is focused and does not include unrelated generated files.
- [ ] Tests cover the affected behavior.
- [x] Documentation was updated where needed.
- [x] No credentials, private task data, or research-run artifacts are included.
- [x] No new dependencies or copied assets were added.
- [x] I have read `.github/CONTRIBUTING.md` and the contribution terms in `LICENSE.md`.