### PR TITLE
docs: fix contributing guide link

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,7 +1,7 @@
 # Contributing to Praxist
 
 The canonical contribution workflow is maintained in
-[`docs/guides/contributing.md`](../docs/guides/contributing.md). Read it together
+[`docs/guides/contributing.md`](https://github.com/sapientinc/PRAXIST/blob/main/docs/guides/contributing.md). Read it together
 with [`AGENTS.md`](../AGENTS.md) before changing code, tests, documentation,
 templates, examples, or skills.
 


### PR DESCRIPTION
## Summary
- use an explicit repository URL for the canonical contributing guide
- avoid GitHub homepage/modal relative-link resolution failures

## Verification
- confirmed the target exists on `main`
- confirmed the target URL returns HTTP 200
- `git diff --check`