### PR TITLE
docs: clarify workflow stage placeholder guidance

### DIFF
--- a/docs/guides/workflow-stages.md
+++ b/docs/guides/workflow-stages.md
@@ -24,6 +24,14 @@ cohort. See [Research Topology Audit API](research-topology-and-module-api.md).
 registered interface placeholders, not product modules. They remain disabled
 by default and do not provide ideation or paper-writing workflows.
 
+Do not implement behavior for these placeholders as an isolated or casual
+contribution. Before either stage becomes a supported workflow, a design
+proposal should define its expected artifacts, lifecycle, budget behavior,
+and test/conformance requirements.
+
+Executable stage semantics belong in Python workflow plugins and should include
+the corresponding conformance coverage.
+
 ## Local Reviewer
 
 `workflow_stage:reviewer_stub` provides an optional local artifact and

--- a/docs/guides/workflow-stages.md
+++ b/docs/guides/workflow-stages.md
@@ -24,13 +24,10 @@ cohort. See [Research Topology Audit API](research-topology-and-module-api.md).
 registered interface placeholders, not product modules. They remain disabled
 by default and do not provide ideation or paper-writing workflows.
 
-Do not implement behavior for these placeholders as an isolated or casual
-contribution. Before either stage becomes a supported workflow, a design
-proposal should define its expected artifacts, lifecycle, budget behavior,
-and test/conformance requirements.
-
-Executable stage semantics belong in Python workflow plugins and should include
-the corresponding conformance coverage.
+To develop either placeholder into a supported workflow, start with a design
+proposal covering its expected artifacts, lifecycle, budget behavior, and
+conformance requirements. Its implementation must then satisfy the executable
+stage contract below.
 
 ## Local Reviewer
 


### PR DESCRIPTION
## Summary

Clarify that the ideation and paper-writing workflow stages are interface
placeholders, and document that developing either into a supported workflow
starts with a design proposal covering expected artifacts, lifecycle, budget
behavior, and conformance requirements.

Integrates #113 from @Ritanshu-Kumar. Closes #44.

## Scope

- Affected modules or public contracts: `docs/guides/workflow-stages.md` only.
- Compatibility considerations: none, documentation-only.
- Task-agnostic rationale: no shared Praxist behavior changes.

## Verification

- `git diff --check` passed; documentation diff reviewed.
- Documentation-only faster path per `.github/CONTRIBUTING.md`; no real-task
  validation required.
- Required `guardrails (py3.11)` and `guardrails (py3.12)` run on this PR.

## Checklist

- [x] The change is focused and does not include unrelated generated files.
- [ ] Tests cover the affected behavior. (documentation-only)
- [x] Documentation, templates, examples, and skills were updated where needed.
- [x] No credentials, private task data, or research-run artifacts are included.
- [x] New dependencies and copied assets include their source and license terms.
- [x] I have read `.github/CONTRIBUTING.md` and the contribution terms in `LICENSE.md`.