### PR TITLE
docs: add good first contribution guidance

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -44,6 +44,19 @@ Before making a substantial change, please consult:
 Keep changes focused, avoid task-specific assumptions in shared code, and update
 tests and documentation at the affected boundary.
 
+## Good First Contributions
+
+For a first contribution, prefer one independently verifiable boundary:
+
+- fix a documentation link or wording while preserving its authoritative source;
+- add focused tests for an existing contract or generic plugin;
+- improve generated-reference consistency checks; or
+- graduate one small file from the Pyrefly exclusions.
+
+Changes listed under [Changes That Need Extra Care](#changes-that-need-extra-care)
+are also welcome. Open an issue or draft pull request first so maintainers can
+help define a safe scope before implementation.
+
 ## What Happens After Submission
 
 1. **Review.** Maintainers examine each open issue and pull request for


### PR DESCRIPTION
## Summary

Add good-first-contribution guidance to the contributing guide so new
contributors can identify well-scoped, independently verifiable starting points.

Combines the overlapping submissions #108 from @Vardhan2858 and #112 from
@ateto3, per the Pull Request Transfer and Credit policy. Closes #45.

## Scope

- Affected modules or public contracts: `.github/CONTRIBUTING.md` only.
- Compatibility considerations: none, documentation-only.
- Task-agnostic rationale: no shared Praxist behavior changes.

## Verification

- `git diff --check` passed; documentation diff reviewed.
- Documentation-only faster path per `.github/CONTRIBUTING.md`.
- Required `guardrails (py3.11)` and `guardrails (py3.12)` run on this PR.

## Checklist

- [x] The change is focused and does not include unrelated generated files.
- [ ] Tests cover the affected behavior. (documentation-only)
- [x] Documentation, templates, examples, and skills were updated where needed.
- [x] No credentials, private task data, or research-run artifacts are included.
- [x] New dependencies and copied assets include their source and license terms.
- [x] I have read `.github/CONTRIBUTING.md` and the contribution terms in `LICENSE.md`.